### PR TITLE
Remove unnecessary ext/hash dependency

### DIFF
--- a/src/Context.php
+++ b/src/Context.php
@@ -121,7 +121,7 @@ final class Context
     private function containsArray(array &$array)
     {
         $keys = array_keys($this->arrays, $array, true);
-        $hash = '_Key_' . hash('sha512', microtime(true));
+        $hash = '_Key_' . microtime(true);
 
         foreach ($keys as $key) {
             $this->arrays[$key][$hash] = $hash;


### PR DESCRIPTION
There is no real point in hashing `microtime(true)` either.

Ultimately, it causes an Error and hides the original error backtrace if the ext/hash extension is missing in phpunit.
