### PR TITLE
Ensure that ext/hash is required, and if missing, it doesn't fall through to the current namespace

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,8 @@
         }
     ],
     "require": {
-        "php": ">=5.3.3"
+        "php": ">=5.3.3",
+	"ext-hash": ">0.0"
     },
     "require-dev": {
         "phpunit/phpunit": "~4.4"

--- a/src/Context.php
+++ b/src/Context.php
@@ -121,7 +121,7 @@ final class Context
     private function containsArray(array &$array)
     {
         $keys = array_keys($this->arrays, $array, true);
-        $hash = '_Key_' . hash('sha512', microtime(true));
+        $hash = '_Key_' . \hash('sha512', microtime(true));
 
         foreach ($keys as $key) {
             $this->arrays[$key][$hash] = $hash;


### PR DESCRIPTION
I had to compile PHP 7 without ext/hash and encountered the following error:

```
Uncaught Error in vendor/sebastian/recursion-context/src/Context.php on line 124: Call to undefined function SebastianBergmann\RecursionContext\hash()
```

Unprefixed functions only fall through to the global namespace if they are built in to PHP.

Because the call to `\hash()` is not prefixed with `\` it does not fall through to the global context, making it look like a bad call to `SebastianBergmann\RecursionContext\hash()` — when in fact it's a missing extension.
