### PR TITLE
Fixed issue #3 - Use an O(1) approach for each array check

### DIFF
--- a/src/Context.php
+++ b/src/Context.php
@@ -92,9 +92,25 @@ final class Context
             return $key;
         }
 
+        $key = count($this->arrays);
         $this->arrays[] = &$array;
 
-        return count($this->arrays) - 1;
+        if (!isset($array[PHP_INT_MAX]) && !isset($array[PHP_INT_MAX - 1])) {
+            $array[] = $key;
+            $array[] = $this->objects;
+        } else { /* cover the improbable case too */
+            do {
+                $key = random_int(PHP_INT_MIN, PHP_INT_MAX);
+            } while (isset($array[$key]));
+            $array[$key] = $key;
+
+            do {
+                $key = random_int(PHP_INT_MIN, PHP_INT_MAX);
+            } while (isset($array[$key]));
+            $array[$key] = $this->objects;
+        }
+
+        return $key;
     }
 
     /**
@@ -118,22 +134,8 @@ final class Context
      */
     private function containsArray(array &$array)
     {
-        $keys = array_keys($this->arrays, $array, true);
-        $hash = '_Key_' . microtime(true);
-
-        foreach ($keys as $key) {
-            $this->arrays[$key][$hash] = $hash;
-
-            if (isset($array[$hash]) && $array[$hash] === $hash) {
-                unset($this->arrays[$key][$hash]);
-
-                return $key;
-            }
-
-            unset($this->arrays[$key][$hash]);
-        }
-
-        return false;
+        $end = array_slice($array, -2);
+        return count($end) != 2 || $end[1] !== $this->objects ? false : $end[0];
     }
 
     /**
@@ -148,5 +150,15 @@ final class Context
         }
 
         return false;
+    }
+
+    function __destruct()
+    {
+        foreach($this->arrays as &$array) {
+            if (is_array($array)) {
+                array_pop($array);
+                array_pop($array);
+            }
+        }
     }
 }


### PR DESCRIPTION
This adds two extra elements, one unique identifier (in this case $this->objects, which ought to be definitely not be accessed anywhere else) and the key for that array.

To check whether the array has already been checked, just these extra elements are verified.

At the end, these are removed again.