### PR TITLE
issue #5 Fix dataprovider

### DIFF
--- a/src/Context.php
+++ b/src/Context.php
@@ -136,7 +136,7 @@ final class Context
      */
     private function containsArray(array &$array)
     {
-        $end = array_slice($array, -2);
+        $end = array_slice(array_values($array), -2);
 
         return count($end) != 2 || $end[1] !== $this->objects ? false : $end[0];
     }


### PR DESCRIPTION
Hi!

I have a problem in tests with dataProvider.
When using a serialized array for the DataProvider testty will fail.

See my fragment code test.

```
    /**
     * @param int    $uid
     * @param string $provider
     * @param array  $expected
     * @dataProvider getUserByProviderCredsDataProvider
     */
    public function testGetUserByProviderCreds($uid, $provider, $expected)
    {
        $actual = $this->mapper->getUserByProviderCreds($uid, $provider);

        $this->assertEquals($expected, $actual);
    }

    /**
     * @see testGetUserByProviderCreds
     * @return array
     */
    public function getUserByProviderCredsDataProvider()
    {
        return [
            [
                'uid' => 1111,
                'provider' => 'vk',
                'expected' => [
                    'user_id'      => 'adff5c92-008c-47ac-bad8-11be43ea1469',
                    'provider'     => 'vk',
                    'uid'          => 1111,
                    'access_token' => 'token',
                    'group_id'     => '',
                    'ttl'          => 0,
                    'start_task'   => date_create_from_format('Y-m-d H:i:s', '1970-01-01 00:00:00'),
                ],
            ],
        ];
    }
```