### PR TITLE
Fix: DocBlock

### DIFF
--- a/src/Context.php
+++ b/src/Context.php
@@ -54,7 +54,7 @@ final class Context
      *
      * @throws InvalidArgumentException Thrown if $value is not an array or object
      *
-     * @return int|string the ID of the stored value, either as a string or integer
+     * @return bool|int|string the ID of the stored value, either as a string or integer
      */
     public function add(&$value)
     {


### PR DESCRIPTION
This PR

* [x] fixes a DocBlock

❗️ Blocks #17.

💁‍♂ Running

```
./tools/psalm --config=psalm.xml --no-progress --show-info=false --stats
```

on current `master` yields

```
ERROR: InvalidReturnType - src/Context.php:57:16 - The declared return type 'int|string' for SebastianBergmann\RecursionContext\Context::add is incorrect, got 'bool|int|string'
     * @return int|string the ID of the stored value, either as a string or integer


ERROR: InvalidReturnStatement - src/Context.php:62:20 - The type 'bool|int' does not match the declared return type 'int|string' for SebastianBergmann\RecursionContext\Context::add
            return $this->addArray($value);


------------------------------
2 errors found
------------------------------
3 other issues found.
------------------------------
Psalm can automatically fix 1 of them.
Run Psalm again with
--alter --issues=InvalidReturnType --dry-run
to see what it can fix.
------------------------------

Checks took 0.39 seconds and used 68.638MB of memory
Psalm was able to infer types for 98.8506% of the codebase
-----------------
99% src/Context.php (1 mixed)
```
