### PR TITLE
Fix: Add return type declaration

### DIFF
--- a/src/Context.php
+++ b/src/Context.php
@@ -131,10 +131,8 @@ final class Context
 
     /**
      * @param object $object
-     *
-     * @return string
      */
-    private function addObject($object)
+    private function addObject($object): string
     {
         if (!$this->objects->contains($object)) {
             $this->objects->attach($object);


### PR DESCRIPTION
This PR

* [x] adds a return type declaration to a `private` method