### PR TITLE
Add type annotations for in/out parameters

### DIFF
--- a/src/Context.php
+++ b/src/Context.php
@@ -66,6 +66,10 @@ final class Context
      * @throws InvalidArgumentException Thrown if $value is not an array or object
      *
      * @return bool|int|string the ID of the stored value, either as a string or integer
+     *
+     * @psalm-template T
+     * @psalm-param T $value
+     * @param-out T $value
      */
     public function add(&$value)
     {
@@ -90,6 +94,10 @@ final class Context
      * @throws InvalidArgumentException Thrown if $value is not an array or object
      *
      * @return false|int|string the string or integer ID of the stored value if it has already been seen, or false if the value is not stored
+     *
+     * @psalm-template T
+     * @psalm-param T $value
+     * @param-out T $value
      */
     public function contains(&$value)
     {


### PR DESCRIPTION
Parameter ``$value`` is passed by reference to ``add(&$value)`` and ``contains(&$value)``, which makes psalm to think, these methods may change its type. This PR provides psalm annotations to inform it that type of the parameter remains unchanged. It shall reduce psalm errors appearing in projects that use recursion-context (for example the [exporter](https://github.com/sebastianbergmann/exporter)).

Psalm reports on exporter:

1. Before this patch
```console
ptomulik@barakus:$ tools/psalm --show-info true
Scanning files...
Analyzing files...

E

INFO: MissingParamType - src/Exporter.php:66:28 - Parameter $value has no provided type (see https://psalm.dev/154)
    public function export($value, $indentation = 0)


ERROR: ReferenceConstraintViolation - src/Exporter.php:77:47 - Variable $data is limited to values of type array<array-key, mixed> because it is passed by reference, array<array-key, mixed>|object type found. Use @param-out to specify a different output type (see https://psalm.dev/086)
    public function shortenedRecursiveExport(&$data, Context $context = null)


ERROR: PossiblyInvalidArrayAccess - src/Exporter.php:91:40 - Cannot access array value on non-array variable $data of type object (see https://psalm.dev/109)
                if ($context->contains($data[$key]) !== false) {


ERROR: PossiblyInvalidArrayAccess - src/Exporter.php:96:57 - Cannot access array value on non-array variable $data of type object (see https://psalm.dev/109)
                        $this->shortenedRecursiveExport($data[$key], $context)


ERROR: ReferenceConstraintViolation - src/Exporter.php:104:9 - Variable $data is limited to values of type array<array-key, mixed> because it is passed by reference, array<array-key, mixed>|object type found. Use @param-out to specify a different output type (see https://psalm.dev/086)
        return implode(', ', $result);


INFO: MissingParamType - src/Exporter.php:120:37 - Parameter $value has no provided type (see https://psalm.dev/154)
    public function shortenedExport($value)


INFO: MissingParamType - src/Exporter.php:162:29 - Parameter $value has no provided type (see https://psalm.dev/154)
    public function toArray($value)


ERROR: InvalidArgument - src/Exporter.php:241:17 - Argument 2 of sprintf expects float|int|string, resource provided (see https://psalm.dev/004)
                $value,


ERROR: ArgumentTypeCoercion - src/Exporter.php:280:23 - Argument 1 of count expects Countable|ResourceBundle|SimpleXMLElement|array<array-key, mixed>, parent type array<array-key, mixed>|object provided (see https://psalm.dev/193)
            if (count($array) > 0) {


ERROR: PossiblyInvalidArrayAccess - src/Exporter.php:286:48 - Cannot access array value on non-array variable $value of type object (see https://psalm.dev/109)
                        $this->recursiveExport($value[$k], $indentation + 1, $processed)


ERROR: InvalidScalarArgument - src/Exporter.php:293:46 - Argument 2 of sprintf expects float|int|string, bool|int|string provided (see https://psalm.dev/012)
            return sprintf('Array &%s (%s)', $key, $values);


ERROR: InvalidScalarArgument - src/Exporter.php:320:58 - Argument 3 of sprintf expects float|int|string, bool|int|string provided (see https://psalm.dev/012)
            return sprintf('%s Object &%s (%s)', $class, $hash, $values);


------------------------------
9 errors found
------------------------------
3 other issues found.
------------------------------
Psalm can automatically fix 2 issues.
Run Psalm again with 
--alter --issues=MissingParamType --dry-run
to see what it can fix.
------------------------------
```

after this patch

```console
ptomulik@barakus:$ tools/psalm --show-info true
Scanning files...
Analyzing files...

E

INFO: MissingParamType - src/Exporter.php:66:28 - Parameter $value has no provided type (see https://psalm.dev/154)
    public function export($value, $indentation = 0)


INFO: MissingParamType - src/Exporter.php:120:37 - Parameter $value has no provided type (see https://psalm.dev/154)
    public function shortenedExport($value)


INFO: MissingParamType - src/Exporter.php:162:29 - Parameter $value has no provided type (see https://psalm.dev/154)
    public function toArray($value)


ERROR: InvalidArgument - src/Exporter.php:241:17 - Argument 2 of sprintf expects float|int|string, resource provided (see https://psalm.dev/004)
                $value,


ERROR: InvalidScalarArgument - src/Exporter.php:293:46 - Argument 2 of sprintf expects float|int|string, bool|int|string provided (see https://psalm.dev/012)
            return sprintf('Array &%s (%s)', $key, $values);


ERROR: ConflictingReferenceConstraint - src/Exporter.php:296:9 - There is more than one pass-by-reference constraint on $value (see https://psalm.dev/085)
        if (is_object($value)) {


ERROR: InvalidScalarArgument - src/Exporter.php:320:58 - Argument 3 of sprintf expects float|int|string, bool|int|string provided (see https://psalm.dev/012)
            return sprintf('%s Object &%s (%s)', $class, $hash, $values);


------------------------------
4 errors found
------------------------------
3 other issues found.
------------------------------
Psalm can automatically fix 2 issues.
Run Psalm again with 
--alter --issues=MissingParamType --dry-run
to see what it can fix.
```