### PR TITLE
Don't clobber null values if array_key_exists(PHP_INT_MAX, $array)

### DIFF
--- a/src/Context.php
+++ b/src/Context.php
@@ -11,6 +11,7 @@ namespace SebastianBergmann\RecursionContext;
 
 use const PHP_INT_MAX;
 use const PHP_INT_MIN;
+use function array_key_exists;
 use function array_pop;
 use function array_slice;
 use function count;
@@ -82,21 +83,25 @@ final class Context
         $key            = count($this->arrays);
         $this->arrays[] = &$array;
 
-        if (!isset($array[PHP_INT_MAX]) && !isset($array[PHP_INT_MAX - 1])) {
+        if (!array_key_exists(PHP_INT_MAX, $array) && !array_key_exists(PHP_INT_MAX-1, $array)) {
             $array[] = $key;
             $array[] = $this->objects;
         } else { /* cover the improbable case too */
+            /* Note that array_slice (used in containsArray) will return the
+             * last two values added *not necessarily* the highest integer
+             * keys in the array, so the order of these writes to $array
+             * is important, but the actual keys used is not. */
             do {
                 /** @noinspection PhpUnhandledExceptionInspection */
                 $key = random_int(PHP_INT_MIN, PHP_INT_MAX);
-            } while (isset($array[$key]));
+            } while (array_key_exists($key, $array));
 
             $array[$key] = $key;
 
             do {
                 /** @noinspection PhpUnhandledExceptionInspection */
                 $key = random_int(PHP_INT_MIN, PHP_INT_MAX);
-            } while (isset($array[$key]));
+            } while (array_key_exists($key, $array));
 
             $array[$key] = $this->objects;
         }


### PR DESCRIPTION
Handle the (extremely unusual) case where the `$array[PHP_INT_MAX] = null;` ; don't clobber the key in that case.