### PR TITLE
Improve the generic types

### DIFF
--- a/src/Context.php
+++ b/src/Context.php
@@ -44,7 +44,7 @@ final class Context
     }
 
     /**
-     * @psalm-template T
+     * @psalm-template T of object|array
      *
      * @psalm-param T $value
      *
@@ -60,7 +60,7 @@ final class Context
     }
 
     /**
-     * @psalm-template T
+     * @psalm-template T of object|array
      *
      * @psalm-param T $value
      *


### PR DESCRIPTION
phpstan does not like when you have a template type for which the bound (which was `mixed` before due to being omitted) is not compatible with the native parameter type. Because of that, it would ignore the `@psalm-template` annotation and then cause issues with the `@param-out` type.