### PR TITLE
Use more efficient `spl_object_id()` over `spl_object_hash()`

### DIFF
--- a/src/Context.php
+++ b/src/Context.php
@@ -17,7 +17,7 @@ use function array_slice;
 use function count;
 use function is_array;
 use function random_int;
-use function spl_object_hash;
+use function spl_object_id;
 use SplObjectStorage;
 
 final class Context
@@ -114,13 +114,13 @@ final class Context
         return $key;
     }
 
-    private function addObject(object $object): string
+    private function addObject(object $object): int
     {
         if (!$this->objects->contains($object)) {
             $this->objects->attach($object);
         }
 
-        return spl_object_hash($object);
+        return spl_object_id($object);
     }
 
     private function containsArray(array $array): false|int
@@ -130,10 +130,10 @@ final class Context
         return isset($end[1]) && $end[1] === $this->objects ? $end[0] : false;
     }
 
-    private function containsObject(object $value): false|string
+    private function containsObject(object $value): false|int
     {
         if ($this->objects->contains($value)) {
-            return spl_object_hash($value);
+            return spl_object_id($value);
         }
 
         return false;

--- a/tests/ContextTest.php
+++ b/tests/ContextTest.php
@@ -10,7 +10,7 @@
 namespace SebastianBergmann\RecursionContext;
 
 use const PHP_INT_MAX;
-use function spl_object_hash;
+use function spl_object_id;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
@@ -49,10 +49,10 @@ final class ContextTest extends TestCase
         $storage->attach($obj2);
 
         return [
-            [$obj, spl_object_hash($obj)],
-            [$obj2, spl_object_hash($obj2)],
-            [$obj3, spl_object_hash($obj3)],
-            [$storage, spl_object_hash($storage)],
+            [$obj, spl_object_id($obj)],
+            [$obj2, spl_object_id($obj2)],
+            [$obj3, spl_object_id($obj3)],
+            [$storage, spl_object_id($storage)],
             [$obj->array, 0],
             [$obj->array2, 0],
             [$obj->array3, 0],


### PR DESCRIPTION
similar to https://github.com/sebastianbergmann/phpunit/pull/4838