### PR TITLE
Avoid deprecated SplObjectStorage::attach/contains for PHP 8.5

### DIFF
--- a/src/Context.php
+++ b/src/Context.php
@@ -128,8 +128,8 @@ final class Context
 
     private function addObject(object $object): int
     {
-        if (!$this->objects->contains($object)) {
-            $this->objects->attach($object);
+        if (!$this->objects->offsetExists($object)) {
+            $this->objects->offsetSet($object);
         }
 
         return spl_object_id($object);
@@ -154,7 +154,7 @@ final class Context
 
     private function containsObject(object $value): false|int
     {
-        if ($this->objects->contains($value)) {
+        if ($this->objects->offsetExists($value)) {
             return spl_object_id($value);
         }
 

--- a/tests/ContextTest.php
+++ b/tests/ContextTest.php
@@ -49,7 +49,7 @@ final class ContextTest extends TestCase
         $obj->self        = $obj;
 
         $storage = new SplObjectStorage;
-        $storage->attach($obj2);
+        $storage->offsetSet($obj2);
 
         return [
             [$obj, spl_object_id($obj)],


### PR DESCRIPTION
ref https://wiki.php.net/rfc/deprecations_php_8_5#deprecate_splobjectstoragecontains_splobjectstorageattach_and_splobjectstoragedetach